### PR TITLE
single space missing in behat.yml-dist. yaml parser throws error:

### DIFF
--- a/behat.yml-dist
+++ b/behat.yml-dist
@@ -10,7 +10,7 @@ default:
                 debug:
                     screenshot_dir: "."
                     screen_id: ":0"
-               system:
+                system:
                     #root should never end up with /.
                     root: "."
                 json:


### PR DESCRIPTION
[Symfony\Component\Yaml\Exception\ParseException]
Indentation problem in "\/Users\/sam\/behatch-skel-retry\/behat.yml" at line 13 (near "   system:").
